### PR TITLE
Add Status Display Types and two new fields

### DIFF
--- a/Sources/SwordRPC/Types/Enums.swift
+++ b/Sources/SwordRPC/Types/Enums.swift
@@ -50,3 +50,14 @@ public enum ActivityType: Int, Codable {
     /// "Competing in Arena World Champions"
     case competing = 5
 }
+
+/// The displayed status types.
+/// https://discord.com/developers/docs/events/gateway-events#activity-object-status-display-types
+public enum StatusDisplayType: Int, Codable {
+    /// "Playing <name>"
+    case name = 0
+    /// "Playing <state>"
+    case state = 1
+    /// "Playing <details>"
+    case details = 2
+}

--- a/Sources/SwordRPC/Types/RichPresence.swift
+++ b/Sources/SwordRPC/Types/RichPresence.swift
@@ -11,13 +11,16 @@ import Foundation
 public struct RichPresence: Encodable {
     public var assets = Assets()
     public var details = ""
+    public var details_url: String?
     public var instance = true
     public var party = Party()
     public var secrets: Secrets?
     public var state = ""
+    public var state_url: String?
     public var timestamps = Timestamps()
     public var buttons: [Button]?
     public var type: ActivityType?
+    public var status_display_type: StatusDisplayType?
 
     public init() {}
 }

--- a/Tests/SwordRPCTests/SwordRPCTests.swift
+++ b/Tests/SwordRPCTests/SwordRPCTests.swift
@@ -27,13 +27,18 @@ class SwordRPC_DiscordTests: XCTestCase, SwordRPCDelegate {
         // Set to listening status
         presence.type = .listening
 
-        // Assign state & details.
-        presence.state = "Love Me Again"
-        presence.details = "John Newman – Tribute"
+        // Assign details & state.
+        presence.details = "Love Me Again"
+        presence.details_url = "https://music.apple.com/us/album/love-me-again/1440813192?i=1440813380"
+        presence.state = "John Newman"
+        presence.state_url = "https://music.apple.com/us/artist/john-newman/649230577"
+        
+        // Show song title instead of "Music."
+        presence.status_display_type = .details
 
         // Assign image properties.
         presence.assets.largeImage = "big_sur_logo"
-        presence.assets.largeText = "Apple Music"
+        presence.assets.largeText = "Tribute" // This is used as the album text in the "Listening" status.
         presence.assets.smallImage = "play"
         presence.assets.smallText = "Playing"
 


### PR DESCRIPTION
- Add `status_display_type` support (see https://discord.com/developers/docs/events/gateway-events#activity-object-status-display-types)
- Add `details_url` and `state_url`
- Updated test case to reflect the above changes